### PR TITLE
fix: null-check getFileLocations and skip upload for finalized files

### DIFF
--- a/src.ts/indexer/Indexer.ts
+++ b/src.ts/indexer/Indexer.ts
@@ -338,18 +338,19 @@ export class Indexer extends HttpProvider {
     ): Promise<[Downloader | null, Error | null]> {
         console.log(`Getting file locations for root hash: ${rootHash}`)
         const locations = await this.getFileLocations(rootHash)
-        console.log(
-            `Found ${locations.length} locations for ${rootHash}:`,
-            locations.map((l) => l.url)
-        )
 
-        if (locations.length === 0) {
+        if (!locations || locations.length === 0) {
             console.error(`No locations found for root hash: ${rootHash}`)
             return [
                 null,
                 new Error(`Failed to get file locations for ${rootHash}`),
             ]
         }
+
+        console.log(
+            `Found ${locations.length} locations for ${rootHash}:`,
+            locations.map((l) => l.url)
+        )
 
         const clients: StorageNode[] = []
         locations.forEach((node) => {

--- a/src.ts/transfer/Uploader.ts
+++ b/src.ts/transfer/Uploader.ts
@@ -76,6 +76,11 @@ export class Uploader {
         let receipt: any = null
         let info = await this.findExistingFileInfo(rootHash)
 
+        if (info !== null && info.finalized) {
+            console.log('File already finalized on-chain, skipping upload')
+            return [{ txHash: '', rootHash }, null]
+        }
+
         if (!mergedOpts.skipTx || info === null) {
             const submitter =
                 mergedOpts.submitter && mergedOpts.submitter.length > 0


### PR DESCRIPTION
## Summary

Fixes two bugs that chain together to crash `Indexer.download()` after re-uploading the same data.

- **Null-check `getFileLocations` result** — `newDownloaderFromIndexerNodes` now checks for `null` before accessing `.length` and `.map()`, preventing the unhandled `TypeError`
- **Skip upload for finalized files** — `uploadFile()` returns early when `findExistingFileInfo()` shows the file is already finalized, avoiding duplicate tx sequences and wasted gas

## Changes

**`src.ts/indexer/Indexer.ts`** — Move null/empty check before `locations.length` access (3 lines)

**`src.ts/transfer/Uploader.ts`** — Add early return when `info.finalized === true` (4 lines)

## Reproduction

Both bugs are confirmed reproducible on `@0gfoundation/0g-ts-sdk@1.2.1` (testnet + mainnet). See repro script and full root cause analysis in #49.

Fixes #49