### PR TITLE
fix: handle null from getFileLocations + default-skip finalized re-up…

### DIFF
--- a/src.ts/indexer/Indexer.ts
+++ b/src.ts/indexer/Indexer.ts
@@ -41,7 +41,10 @@ export class Indexer extends HttpProvider {
             method: 'indexer_getFileLocations',
             params: [rootHash],
         })
-        return res as ShardedNode[]
+        // The indexer may legitimately return null (e.g. for a root hash that
+        // has no known locations yet). Normalize to [] so callers can treat
+        // "no results" uniformly and don't crash reading `.length` / `.map`.
+        return (res ?? []) as ShardedNode[]
     }
 
     // ─── Node selection ───────────────────────────────────────────────────

--- a/src.ts/transfer/types.ts
+++ b/src.ts/transfer/types.ts
@@ -20,7 +20,7 @@ export interface UploadOption {
     expectedReplica?: number // expected number of replications
     fragmentSize?: number // size of each fragment in bytes
     skipTx?: boolean // skip sending transaction on chain, this can set to true only if the data has already settled on chain before
-    skipIfFinalized?: boolean // skip upload entirely if the file already exists and is finalized on storage nodes
+    skipIfFinalized?: boolean // skip upload entirely if the file already exists and is finalized on storage nodes (default: true — explicitly set false to force a re-upload; you'll pay gas and storage fee again)
     fee?: bigint // fee to pay for data storage
     nonce?: bigint // nonce for the transaction
     onProgress?: (message: string) => void // optional progress callback
@@ -42,7 +42,7 @@ export const defaultUploadOption: Omit<
     expectedReplica: 1,
     fragmentSize: 1024 * 1024 * 1024 * 4, // 4GB
     skipTx: false,
-    skipIfFinalized: false,
+    skipIfFinalized: true,
     fee: BigInt(0),
 }
 


### PR DESCRIPTION
…loads

Two bugs that chained together to crash Indexer.download() after re-uploading the same data:

1. Indexer.getFileLocations could return null (JSON-RPC 'not found') but the TS signature asserted ShardedNode[]. newDownloaderFromIndexerNodes then hit TypeError: Cannot read properties of null (reading 'length'). Normalize null -> [] so every caller's existing 'length === 0' branch handles it cleanly.

2. UploadOption.skipIfFinalized defaulted to false, so re-uploading a file that was already finalized on storage nodes would submit a fresh tx anyway — new txSeq, wasted gas + storage fee. Flip the default to true. Callers who genuinely want a re-upload can pass skipIfFinalized: false explicitly (they're opting in to the cost).